### PR TITLE
Create fit.ba

### DIFF
--- a/lib/domains/ba/fit.ba
+++ b/lib/domains/ba/fit.ba
@@ -1,0 +1,1 @@
+Faculty of Information Technology


### PR DESCRIPTION
Please add our faculty (Faculty of Information Technology, fit.ba - used by educators and edu.fit.ba used by students). Check out official site fit.ba or wiki entry http://en.wikipedia.org/wiki/Faculty_of_Information_Technology,_University_Džemal_Bijedić_of_Mostar